### PR TITLE
Add validation for index numbers and supported years, include full index number and school name in results

### DIFF
--- a/src/NectaResultScraper.php
+++ b/src/NectaResultScraper.php
@@ -2,6 +2,8 @@
 
 namespace NectaResultScraper;
 
+require_once 'vendor/autoload.php';
+
 
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\HttpClient\HttpClient;
@@ -46,14 +48,7 @@ class NectaResultScraper
                 $browser = new HttpBrowser(HttpClient::create(['timeout' => 30]));
                 $crawler = $browser->request('GET', $url);
 
-                $schoolName = '';
-                $schoolName = $crawler->filter('p')->eq(2)->text();
-                $schoolName = trim($schoolName);
-                $schoolNumberForName = strtoupper($schoolNumber);
-                if (strpos($schoolName, $schoolNumberForName) !== false) {
-                    $schoolName = str_replace($schoolNumberForName, '', $schoolName);
-                }
-                $schoolName = trim($schoolName);          
+                $schoolName = $this->getSchoolName($crawler, $schoolNumber);       
 
                 $tables = $crawler->filter("table")->eq($index);
                 $examinationNumber = $schoolNumber . "/" . $studentNumber;
@@ -117,6 +112,22 @@ class NectaResultScraper
             return "https://onlinesys.necta.go.tz/results/2016/csee/results/{$schoolNumber}.htm";
         }
     }
+
+    private function getSchoolName($crawler, $schoolNumber): string
+{
+   
+    $schoolName = $crawler->filter('p')->eq(2)->text();
+    $schoolName = trim($schoolName);
+
+    
+    $schoolNumberForName = strtoupper($schoolNumber);
+    if (strpos($schoolName, $schoolNumberForName) !== false) {
+        $schoolName = str_replace($schoolNumberForName, '', $schoolName);
+    }
+
+    return trim($schoolName);
+}
+
 
     private function isIndexNumberValid(string $indexNumber): bool
     {

--- a/src/NectaResultScraper.php
+++ b/src/NectaResultScraper.php
@@ -2,7 +2,6 @@
 
 namespace NectaResultScraper;
 
-require_once 'vendor/autoload.php';
 
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\HttpClient\HttpClient;
@@ -12,6 +11,7 @@ use Throwable;
  * Necta Result Scraper
  *
  * @author Alex Leo <loealex175@gmail.com>
+ * @contributor Issa Hakimu <issahakimuakida365@gmail.com>
  */
 class NectaResultScraper
 {
@@ -26,6 +26,9 @@ class NectaResultScraper
         try {
             if (!$this->isIndexNumberValid($indexNumber)) {
                 return ['error' => 'Invalid index number'];
+            }
+            if(!$this->isValidYearInIndexNumber($indexNumber)){
+                return ['error' => 'This package supports result scraping for years from 2015 to 2024'];
             } else {
                 if (strpos($indexNumber, '.') !== false) {
                     $substrings = explode('.', $indexNumber);
@@ -42,10 +45,21 @@ class NectaResultScraper
                 $result = [];
                 $browser = new HttpBrowser(HttpClient::create(['timeout' => 30]));
                 $crawler = $browser->request('GET', $url);
+
+                $schoolName = '';
+                $schoolName = $crawler->filter('p')->eq(2)->text();
+                $schoolName = trim($schoolName);
+                $schoolNumberForName = strtoupper($schoolNumber);
+                if (strpos($schoolName, $schoolNumberForName) !== false) {
+                    $schoolName = str_replace($schoolNumberForName, '', $schoolName);
+                }
+                $schoolName = trim($schoolName);          
+
                 $tables = $crawler->filter("table")->eq($index);
                 $examinationNumber = $schoolNumber . "/" . $studentNumber;
 
-                $tables->filter('tr')->each(function ($tr) use ($examinationNumber, &$found, &$result, $url) {
+
+                $tables->filter('tr')->each(function ($tr) use ($examinationNumber, &$found, &$result, $url, $schoolName, $year) {
                     $row = [];
                     $tr->filter('td')->each(function ($td) use (&$row) {
                         $row[] = trim($td->text());
@@ -53,6 +67,7 @@ class NectaResultScraper
 
                     if (strtolower($row[0]) == $examinationNumber) {
                         $found = true;
+                        $indexNumber = $row[0] . '/' . $year;
                         $gender = $row[1];
                         $division = $row[3];
                         $points = $row[2];
@@ -62,6 +77,8 @@ class NectaResultScraper
                         $grades = $matches[2];
                         $subjectsGrades = array_combine($subjects, $grades);
                         $result = [
+                            'index_number' => $indexNumber,
+                            'secondary_school' => $schoolName,
                             'gender' => $gender,
                             'division' => $division,
                             'points' => $points,
@@ -103,7 +120,18 @@ class NectaResultScraper
 
     private function isIndexNumberValid(string $indexNumber): bool
     {
-        $regex = '/^S\d{4}\.\d{4}\.\d{4}$|^S\d{4}\/\d{4}\/\d{4}$/';
-        return preg_match($regex, $indexNumber) === 1;
+        $pattern = "/^[QPS]\d{4}\/\d{4}\/\d{4}$/";
+        return preg_match($pattern, $indexNumber) === 1;
+    }
+
+    private function isValidYearInIndexNumber(string $indexNumber) : bool {
+        $pattern = "/^[QPS]\d{4}\/\d{4}\/(\d{4})$/";
+        
+        if (preg_match($pattern, $indexNumber, $matches)) {
+            $year = (int) $matches[1];
+            return $year >= 2015;
+        }
+        
+        return false;
     }
 }


### PR DESCRIPTION
### Summary:
This pull request introduces the following updates to the Necta Result Scraper package:

1. **Index Number Validation:**
   - Ensures that the index numbers start with 'S', 'P', or 'Q' are accepted.
   - Validates the index number to only support years from 2015 and onward, ensuring the scraper works for a defined set of years.

2. **Results Enhancement:**
   - Includes the full examination index number in the results.
   - Adds the secondary school name in the returned results.

### Benefits:
- These changes improve the accuracy and robustness of the scraper by ensuring that only valid and supported index numbers are processed.
- Including the full index number and school name provides better clarity and context in the results.

### Testing:
- The changes have been tested with a variety of index numbers and school names to ensure proper validation and result formatting.

Please review the changes and let me know if further adjustments are needed.
